### PR TITLE
Add explicit-dependencies sbt plugin

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   /** Test dependencies only required in `test` */
   private val TestDependencies: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.0.5",
-    "org.mockito" % "mockito-core" % "2.23.0"
+    "org.mockito" % "mockito-core" % "2.23.4"
   ).map(_ % Test)
 
   /** The list of all dependencies for the connector */

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.danielnixon" % "sbt-extrawarts" % "1.0.3")
 
 // Adds a `assembly` task to create a fat JAR with all of its dependencies
 // https://github.com/sbt/sbt-assembly
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
 // Adds a `BuildInfo` tasks
 // https://github.com/sbt/sbt-buildinfo
@@ -57,6 +57,10 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 // Adds a `git` plugin
 // https://github.com/sbt/sbt-git
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+
+// Adds a `sbt-explicit-dependencies` plugin
+// https://github.com/cb372/sbt-explicit-dependencies
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.6")
 
 // Setup this and project/project/plugins.sbt for formatting project/*.scala files with scalafmt
 inThisBuild(

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -70,6 +70,15 @@ run_api_doc () {
   ./sbtx ++$TRAVIS_SCALA_VERSION doc
 }
 
+run_explicit_dependencies () {
+  echo "############################################"
+  echo "#                                          #"
+  echo "#        Unused Dependencies               #"
+  echo "#                                          #"
+  echo "############################################"
+  ./sbtx ++$TRAVIS_SCALA_VERSION undeclaredCompileDependencies unusedCompileDependencies
+}
+
 run_dependency_info () {
   echo "############################################"
   echo "#                                          #"
@@ -121,6 +130,7 @@ run_unit_tests
 run_integration_tests
 run_coverage_report
 run_api_doc
+run_explicit_dependencies
 run_dependency_info
 run_shell_check
 run_assembly


### PR DESCRIPTION
With each build it will show unused (also undeclared) dependencies.