### PR TITLE
Support SAS Token to access Azure Blob Storage

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -132,6 +132,22 @@ INTO SCRIPT ETL.EXPORT_PATH WITH
   PARALLELISM        = 'iproc()';
 ```
 
+Furthermore, you can use Shared Access Signature (SAS) token to access the Azure
+Blob Storage. In that case, you need to provide the Azure SAS token and
+container name as parameters.
+
+For example:
+```sql
+IMPORT INTO SALES_POSITIONS
+FROM SCRIPT ETL.IMPORT_PATH WITH
+  BUCKET_PATH          = 'wasbs://AZURE_CONTAINER_NAME@AZURE_ACCOUNT_NAME.blob.core.windows.net/orc/sales-positions/*'
+  DATA_FORMAT          = 'ORC'
+  AZURE_ACCOUNT_NAME   = 'AZURE_ACCOUNT_NAME'
+  AZURE_CONTAINER_NAME = 'AZURE_CONTAINER_NAME'
+  AZURE_SAS_TOKEN      = 'AZURE_SAS_TOKEN'
+  PARALLELISM          = 'nproc()';
+```
+
 ## Azure Data Lake (Gen1) Storage
 
 Similarly the following parameters and values are required in order to access

--- a/src/main/scala/com/exasol/cloudetl/bucket/AzureBlobBucket.scala
+++ b/src/main/scala/com/exasol/cloudetl/bucket/AzureBlobBucket.scala
@@ -5,6 +5,10 @@ import org.apache.hadoop.conf.Configuration
 /** A [[Bucket]] implementation for the Azure Blob Storage */
 final case class AzureBlobBucket(path: String, params: Map[String, String]) extends Bucket {
 
+  private[this] val AZURE_CONTAINER_NAME: String = "AZURE_CONTAINER_NAME"
+  private[this] val AZURE_SAS_TOKEN: String = "AZURE_SAS_TOKEN"
+  private[this] val AZURE_SECRET_KEY: String = "AZURE_SECRET_KEY"
+
   /** @inheritdoc */
   override val bucketPath: String = path
 
@@ -12,8 +16,14 @@ final case class AzureBlobBucket(path: String, params: Map[String, String]) exte
   override val properties: Map[String, String] = params
 
   /** @inheritdoc */
-  override def validate(): Unit =
+  override def validate(): Unit = {
     Bucket.validate(properties, Bucket.AZURE_BLOB_PARAMETERS)
+    if (!params.contains(AZURE_SECRET_KEY) && !params.contains(AZURE_SAS_TOKEN)) {
+      throw new IllegalArgumentException(
+        s"Please provide a value for either $AZURE_SECRET_KEY or $AZURE_SAS_TOKEN!"
+      )
+    }
+  }
 
   /**
    * @inheritdoc
@@ -25,8 +35,6 @@ final case class AzureBlobBucket(path: String, params: Map[String, String]) exte
     validate()
 
     val conf = new Configuration()
-    val accountName = Bucket.requiredParam(params, "AZURE_ACCOUNT_NAME")
-    val accountSecretKey = Bucket.requiredParam(params, "AZURE_SECRET_KEY")
     conf.set("fs.azure", classOf[org.apache.hadoop.fs.azure.NativeAzureFileSystem].getName)
     conf.set("fs.wasb.impl", classOf[org.apache.hadoop.fs.azure.NativeAzureFileSystem].getName)
     conf.set("fs.wasbs.impl", classOf[org.apache.hadoop.fs.azure.NativeAzureFileSystem].getName)
@@ -35,7 +43,16 @@ final case class AzureBlobBucket(path: String, params: Map[String, String]) exte
       "fs.AbstractFileSystem.wasbs.impl",
       classOf[org.apache.hadoop.fs.azure.Wasbs].getName
     )
-    conf.set(s"fs.azure.account.key.$accountName.blob.core.windows.net", accountSecretKey)
+
+    val accountName = Bucket.requiredParam(params, "AZURE_ACCOUNT_NAME")
+    if (params.contains(AZURE_SAS_TOKEN)) {
+      val sasToken = Bucket.requiredParam(params, AZURE_SAS_TOKEN)
+      val containerName = Bucket.requiredParam(params, AZURE_CONTAINER_NAME)
+      conf.set(s"fs.azure.sas.$containerName.$accountName.blob.core.windows.net", sasToken)
+    } else {
+      val secretKey = Bucket.requiredParam(params, AZURE_SECRET_KEY)
+      conf.set(s"fs.azure.account.key.$accountName.blob.core.windows.net", secretKey)
+    }
 
     conf
   }

--- a/src/main/scala/com/exasol/cloudetl/bucket/Bucket.scala
+++ b/src/main/scala/com/exasol/cloudetl/bucket/Bucket.scala
@@ -80,7 +80,7 @@ object Bucket extends LazyLogging {
    * The list of required parameter keys for Azure Blob Storage bucket.
    */
   final val AZURE_BLOB_PARAMETERS: Seq[String] =
-    Seq("AZURE_ACCOUNT_NAME", "AZURE_SECRET_KEY")
+    Seq("AZURE_ACCOUNT_NAME")
 
   /**
    * The list of required keys for Azure Data Lake Storage bucket.


### PR DESCRIPTION
It makes it possible to use Azure Blob Store container SAS token when importing or exporting data to/from Exasol table. This is additional feature to previous Account Secret Key access usage.

Fixes #42.