### PR TITLE
Obtain account and container names from provided path in Azure Blob Storage.

### DIFF
--- a/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
@@ -90,6 +90,11 @@ class StorageProperties(
       .split(";")
       .map { str =>
         val idx = str.indexOf('=')
+        if (idx < 0) {
+          throw new IllegalArgumentException(
+            "Connection object password does not contain key=value pairs!"
+          )
+        }
         str.substring(0, idx) -> str.substring(idx + 1)
       }
       .toMap


### PR DESCRIPTION
This will not enforce users to explicitly provide `AZURE_ACCOUNT_NAME` and `AZURE_CONTAINER_NAME` properties when accessing Azure Blob Storage. 

Since those two values are available in the provided path, we obtain them from it.