### PR TITLE
Use Hadoop Filesystem Path URI instead of java.net.URI

### DIFF
--- a/src/main/scala/com/exasol/cloudetl/bucket/Bucket.scala
+++ b/src/main/scala/com/exasol/cloudetl/bucket/Bucket.scala
@@ -1,7 +1,5 @@
 package com.exasol.cloudetl.bucket
 
-import java.net.URI
-
 import com.exasol.cloudetl.storage.StorageProperties
 import com.exasol.cloudetl.util.FileSystemUtil
 
@@ -60,7 +58,7 @@ abstract class Bucket extends LazyLogging {
    * bucket path.
    */
   final lazy val fileSystem: FileSystem =
-    FileSystem.get(new URI(bucketPath), getConfiguration())
+    FileSystem.get(new Path(bucketPath).toUri, getConfiguration())
 
   /**
    * Get the all the paths in this bucket path.

--- a/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
@@ -1,11 +1,11 @@
 package com.exasol.cloudetl.storage
 
-import java.net.URI
-
 import com.exasol.ExaConnectionInformation
 import com.exasol.ExaMetadata
 import com.exasol.cloudetl.common.AbstractProperties
 import com.exasol.cloudetl.common.CommonProperties
+
+import org.apache.hadoop.fs.Path
 
 /**
  * A specific implementation of
@@ -36,7 +36,7 @@ class StorageProperties(
    * load data, returns the scheme `s3a` value.
    */
   final def getStoragePathScheme(): String =
-    new URI(getStoragePath()).getScheme
+    new Path(getStoragePath()).toUri.getScheme
 
   /** Returns the [[FileFormat]] file format. */
   final def getFileFormat(): FileFormat =

--- a/src/test/scala/com/exasol/cloudetl/storage/StoragePropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/storage/StoragePropertiesTest.scala
@@ -44,6 +44,12 @@ class StoragePropertiesTest extends AnyFunSuite with BeforeAndAfterEach with Moc
     }
   }
 
+  test("getStoragePathScheme returns path scheme with regex pattern") {
+    val path = "s3a://bucket/{year=2019/month=1,year=2019/month=2}/*"
+    properties = Map(StorageProperties.BUCKET_PATH -> path)
+    assert(BaseProperties(properties).getStoragePathScheme() === "s3a")
+  }
+
   test("getFileFormat returns supported file format value") {
     properties = Map(
       StorageProperties.BUCKET_PATH -> "path",


### PR DESCRIPTION
The `java.net.URI` cannot resolve the paths that contain regex patterns,
for example, `'s3a://bucket/{year=2019/month=1,year=2019/month=2}/*'`.

Instead we should use Hadoop Filesystem Path, and then convert the path
to URI using `.toUri()` method.

For example, to obtain the schema from a path:

```scala
new Path(bucketPathString).toUri.getSchema
```