### PR TITLE
Adds `OVERWRITE` parameter for the EXPORT UDF.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -179,6 +179,13 @@ These are optional parameters that usually have default values.
   floor(random()*4)'`. Please check out the [supported cloud storage
   systems](storage/cloud_storages.md) for more examples.
 
+* ``OVERWRITE`` - This property is only relevant to the export SQL statement. If
+  it is set to `true`, the UDF deletes all the files in the export path. By
+  default it is set to `false`. Please keep in mind the delete operation is
+  blocking, it can take time to finish at least proportional to the number of
+  files. If the delete operation is interrupted, the filesystem is left in an
+  intermediate state.
+
 * ``PARQUET_COMPRESSION_CODEC`` - This property is only used in export SQL
   statement. It defines the compression codec to use when exporting data into
   Parquet formatted files. Default value is **uncompressed**. Other compression

--- a/src/main/scala/com/exasol/cloudetl/scriptclasses/ExportPath.scala
+++ b/src/main/scala/com/exasol/cloudetl/scriptclasses/ExportPath.scala
@@ -15,7 +15,7 @@ object ExportPath {
     metadata: ExaMetadata,
     exportSpec: ExaExportSpecification
   ): String = {
-    val storageProperties = StorageProperties(exportSpec.getParameters.asScala.toMap)
+    val storageProperties = StorageProperties(exportSpec.getParameters.asScala.toMap, metadata)
     val bucket = Bucket(storageProperties)
     bucket.validate()
     deleteBucketPathIfRequired(bucket)

--- a/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/storage/StorageProperties.scala
@@ -72,6 +72,15 @@ class StorageProperties(
     get(PARALLELISM).fold(defaultValue)(identity)
 
   /**
+   * Checks if the overwite parameter is set to true.
+   *
+   * If the overwrite parameter is not set, then returns default {@code
+   * false} value.
+   */
+  final def isOverwrite(): Boolean =
+    isEnabled(OVERWRITE)
+
+  /**
    * Returns a new [[StorageProperties]] that merges the key-value pairs
    * parsed from user provided Exasol named connection object.
    */
@@ -104,6 +113,9 @@ object StorageProperties extends CommonProperties {
 
   /** An optional property key name for the parallelism. */
   private[storage] final val PARALLELISM: String = "PARALLELISM"
+
+  /** An optional property key name for the overwite. */
+  private[storage] final val OVERWRITE: String = "OVERWRITE"
 
   /**
    * Returns [[StorageProperties]] from key values map and

--- a/src/test/scala/com/exasol/cloudetl/scriptclasses/ExportPathTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/scriptclasses/ExportPathTest.scala
@@ -1,5 +1,7 @@
 package com.exasol.cloudetl.scriptclasses
 
+import java.nio.file.Files
+
 import scala.collection.JavaConverters._
 
 import com.exasol.cloudetl.storage.StorageProperties
@@ -61,6 +63,42 @@ class ExportPathTest extends PathTest {
     verify(metadata, atLeastOnce).getScriptSchema
     verify(exportSpec, times(1)).getParameters
     verify(exportSpec, times(1)).getSourceColumnNames
+  }
+
+  private[this] def createDummyFiles(path: java.nio.file.Path): Seq[java.nio.file.Path] = {
+    val files = Seq("a.parquet", "b.parquet", "c.parquet").map(path.resolve(_))
+    files.foreach(Files.createFile(_))
+    files
+  }
+
+  test("generateSqlForExportSpec keeps the path files if 'overwrite' parameter is not set") {
+    val bucketPath = Files.createTempDirectory("bucketPath")
+    val files = createDummyFiles(bucketPath)
+    val newProperties = properties ++ Map(
+      "BUCKET_PATH" -> s"file://${bucketPath.toUri.getRawPath}"
+    )
+    when(metadata.getScriptSchema()).thenReturn(schema)
+    when(exportSpec.getParameters()).thenReturn(newProperties.asJava)
+    ExportPath.generateSqlForExportSpec(metadata, exportSpec)
+    assert(Files.exists(bucketPath) === true)
+    assert(Files.list(bucketPath).findAny().isPresent() === true)
+    assert(Files.list(bucketPath).count() === 3)
+
+    files.foreach(Files.deleteIfExists(_))
+    Files.delete(bucketPath)
+  }
+
+  test("generateSqlForExportSpec deletes the path files if 'overwrite' parameter is set") {
+    val bucketPath = Files.createTempDirectory("bucketPath")
+    createDummyFiles(bucketPath)
+    val newProperties = properties ++ Map(
+      "BUCKET_PATH" -> s"file://${bucketPath.toUri.getRawPath}",
+      "OVERWRITE" -> "true"
+    )
+    when(metadata.getScriptSchema()).thenReturn(schema)
+    when(exportSpec.getParameters()).thenReturn(newProperties.asJava)
+    ExportPath.generateSqlForExportSpec(metadata, exportSpec)
+    assert(Files.exists(bucketPath) === false)
   }
 
 }

--- a/src/test/scala/com/exasol/cloudetl/storage/StoragePropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/storage/StoragePropertiesTest.scala
@@ -103,6 +103,15 @@ class StoragePropertiesTest extends AnyFunSuite with BeforeAndAfterEach with Moc
     assert(BaseProperties(properties).getParallelism("nproc()") === "nproc()")
   }
 
+  test("isOverwrite returns true is set") {
+    properties = Map(StorageProperties.OVERWRITE -> "true")
+    assert(BaseProperties(properties).isOverwrite() === true)
+  }
+
+  test("isOverwrite returns default false value if it is not set") {
+    assert(BaseProperties(properties).isOverwrite() === false)
+  }
+
   final def newConnectionInformation(
     username: String,
     password: String


### PR DESCRIPTION
If this parameter is set to `true`, deletes the files inside the export path before starting the export process.