### PR TITLE
Add support for using connection objects with Kafka

### DIFF
--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
@@ -1,12 +1,14 @@
 package com.exasol.cloudetl.kafka
 
+import com.exasol.ExaMetadata
+
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 
 class KafkaConsumerPropertiesIT extends KafkaIntegrationTest {
 
   test("build returns a KafkaConsumer[String, GenericRecord]") {
-    val kafkaConsumer = KafkaConsumerProperties(properties).build()
+    val kafkaConsumer = KafkaConsumerProperties(properties).build(mock[ExaMetadata))
     assert(kafkaConsumer.isInstanceOf[KafkaConsumer[String, GenericRecord]])
   }
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 class KafkaConsumerPropertiesIT extends KafkaIntegrationTest {
 
   test("build returns a KafkaConsumer[String, GenericRecord]") {
-    val kafkaConsumer = KafkaConsumerProperties(properties).build(mock[ExaMetadata]))
+    val kafkaConsumer = KafkaConsumerProperties(properties).build(mock[ExaMetadata])
     assert(kafkaConsumer.isInstanceOf[KafkaConsumer[String, GenericRecord]])
   }
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesIT.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 class KafkaConsumerPropertiesIT extends KafkaIntegrationTest {
 
   test("build returns a KafkaConsumer[String, GenericRecord]") {
-    val kafkaConsumer = KafkaConsumerProperties(properties).build(mock[ExaMetadata))
+    val kafkaConsumer = KafkaConsumerProperties(properties).build(mock[ExaMetadata]))
     assert(kafkaConsumer.isInstanceOf[KafkaConsumer[String, GenericRecord]])
   }
 

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConnectorException.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConnectorException.scala
@@ -1,0 +1,6 @@
+package com.exasol.cloudetl.kafka
+
+class KafkaConnectorException(val message: String, val cause: Throwable)
+    extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -220,7 +220,7 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
     if (hasNamedConnection()) {
       validateConnectionObject()
       val connectionParsedMap =
-        parseConnectionInfo(SSL_KEYSTORE_LOCATION.userPropertyName, Option(exaMetadata))
+        parseConnectionInfo(BOOTSTRAP_SERVERS.userPropertyName, Option(exaMetadata))
       val newProperties = properties ++ connectionParsedMap
       new KafkaConsumerProperties(newProperties)
     } else {

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -229,10 +229,6 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
 
   private[this] def validateConnectionObject(): Unit = {
     val connectionProperties = List(
-      "BOOTSTRAP_SERVERS",
-      "SCHEMA_REGISTRY_URL",
-      "SECURITY_PROTOCOL",
-      "SSL_ENABLED",
       "SSL_KEYSTORE_LOCATION",
       "SSL_KEYSTORE_PASSWORD",
       "SSL_KEY_PASSWORD",

--- a/src/main/scala/com/exasol/cloudetl/scriptclasses/KafkaImport.scala
+++ b/src/main/scala/com/exasol/cloudetl/scriptclasses/KafkaImport.scala
@@ -33,7 +33,7 @@ object KafkaImport extends LazyLogging {
     val minRecords = kafkaProperties.getMinRecordsPerRun()
     val topicPartition = new TopicPartition(topics, partitionId)
 
-    val kafkaConsumer = kafkaProperties.build()
+    val kafkaConsumer = kafkaProperties.build(metadata)
     kafkaConsumer.assign(Arrays.asList(topicPartition))
     kafkaConsumer.seek(topicPartition, partitionNextOffset)
 

--- a/src/main/scala/com/exasol/cloudetl/scriptclasses/KafkaMetadata.scala
+++ b/src/main/scala/com/exasol/cloudetl/scriptclasses/KafkaMetadata.scala
@@ -25,7 +25,7 @@ object KafkaMetadata extends LazyLogging {
       idOffsetPairs += (partitionId -> partitionOffset)
     } while (iterator.next())
 
-    val kafkaConsumerTry = Try(kafkaProperties.build())
+    val kafkaConsumerTry = Try(kafkaProperties.build(metadata))
     kafkaConsumerTry match {
 
       case Failure(ex) =>

--- a/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
@@ -369,6 +369,24 @@ class KafkaConsumerPropertiesTest extends AnyFunSuite with BeforeAndAfterEach wi
     )
   }
 
+  test("build uses connection object in created consumer if supplied") {
+    val propertiesMap = Map(
+      "TOPICS" -> "test-topic",
+      "CONNECTION_NAME" -> "MY_CONNECTION"
+    )
+    val exaMetadata = mock[ExaMetadata]
+    val exaConnectionInformation = mock[ExaConnectionInformation]
+    when(exaMetadata.getConnection("MY_CONNECTION")).thenReturn(exaConnectionInformation)
+    when(exaConnectionInformation.getUser()).thenReturn("")
+    when(exaConnectionInformation.getPassword())
+      .thenReturn("BOOTSTRAP_SERVERS=kafka01.internal:9092")
+
+    val mergedProperties = BaseProperties(propertiesMap).mergeWithConnectionObject(exaMetadata)
+
+    assert(mergedProperties.getTopics === "test-topic")
+    assert(mergedProperties.getBootstrapServers === "kafka01.internal:9092")
+  }
+
   private[this] case class BaseProperties(val params: Map[String, String])
       extends KafkaConsumerProperties(params)
 

--- a/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
@@ -353,7 +353,7 @@ class KafkaConsumerPropertiesTest extends AnyFunSuite with BeforeAndAfterEach wi
     val conflictingProperties = Map(
       "BOOTSTRAP_SERVERS" -> "kafka.broker.com:9092",
       "CONNECTION_NAME" -> "MY_CONNECTION",
-      "SCHEMA_REGISTRY_URL" -> "http://schema-registry.com:8080"
+      "SSL_KEY_PASSWORD" -> "sslK3YP@ssword"
     )
 
     val kafkaConsumerProperties = new BaseProperties(conflictingProperties)

--- a/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
@@ -369,24 +369,6 @@ class KafkaConsumerPropertiesTest extends AnyFunSuite with BeforeAndAfterEach wi
     )
   }
 
-  test("build uses connection object in created consumer if supplied") {
-    val propertiesMap = Map(
-      "TOPICS" -> "test-topic",
-      "CONNECTION_NAME" -> "MY_CONNECTION"
-    )
-    val exaMetadata = mock[ExaMetadata]
-    val exaConnectionInformation = mock[ExaConnectionInformation]
-    when(exaMetadata.getConnection("MY_CONNECTION")).thenReturn(exaConnectionInformation)
-    when(exaConnectionInformation.getUser()).thenReturn("")
-    when(exaConnectionInformation.getPassword())
-      .thenReturn("BOOTSTRAP_SERVERS=kafka01.internal:9092")
-
-    val mergedProperties = BaseProperties(propertiesMap).mergeWithConnectionObject(exaMetadata)
-
-    assert(mergedProperties.getTopics === "test-topic")
-    assert(mergedProperties.getBootstrapServers === "kafka01.internal:9092")
-  }
-
   private[this] case class BaseProperties(val params: Map[String, String])
       extends KafkaConsumerProperties(params)
 


### PR DESCRIPTION
We're looking to work with the cloud ETL support for Kafka, and a clear requirement for us would be to use connection objects, both for enabling access for analysts / data scientists without exposing credentials, and to avoid seeing credentials everywhere in the logs.

I've done my best to implement Kafka support for connection objects similar to how it's done for Kinesis, but I'm very much open to suggestions on changes needed as I don't really have any experience with Scala.