### PR TITLE
Add checks for existing keystore and truststore files when creating Kafka client

### DIFF
--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -1,5 +1,7 @@
 package com.exasol.cloudetl.kafka
 
+import java.nio.file.{Files, Paths}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{Map => MMap}
 
@@ -566,8 +568,6 @@ object KafkaConsumerProperties extends CommonProperties {
   }
 
   private[this] def validate(properties: KafkaConsumerProperties): Unit = {
-    import java.nio.file.{Files, Paths}
-
     if (!properties.containsKey(BOOTSTRAP_SERVERS.userPropertyName)) {
       throw new IllegalArgumentException(
         s"Please provide a value for the "

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -566,17 +566,34 @@ object KafkaConsumerProperties extends CommonProperties {
   }
 
   private[this] def validate(properties: KafkaConsumerProperties): Unit = {
+    import java.nio.file.{Files, Paths}
+
     if (!properties.containsKey(BOOTSTRAP_SERVERS.userPropertyName)) {
       throw new IllegalArgumentException(
         s"Please provide a value for the "
           + s"${BOOTSTRAP_SERVERS.userPropertyName} property!"
       )
     }
+
     if (!properties.hasSchemaRegistryUrl()) {
       throw new IllegalArgumentException(
         s"Please provide a value for the "
           + s"${SCHEMA_REGISTRY_URL.userPropertyName} property!"
       )
+    }
+
+    if (properties.isSSLEnabled()) {
+      if (!Files.isRegularFile(Paths.get(properties.getSSLKeystoreLocation()))) {
+        throw new KafkaConnectorException(
+          s"Unable to find the SSL keystore: ${properties.getSSLKeystoreLocation()}"
+        )
+      }
+
+      if (!Files.isRegularFile(Paths.get(properties.getSSLTruststoreLocation()))) {
+        throw new KafkaConnectorException(
+          s"Unable to find the SSL truststore: ${properties.getSSLTruststoreLocation()}"
+        )
+      }
     }
   }
 


### PR DESCRIPTION
To avoid getting a confusing error deeper in the stack that surfaces to the Exasol query result, check to make sure that the keystore and truststore files actually exist while validating the Kafka client. This allows us to show a more understandable message that can be acted on directly.