### PR TITLE
Fixed release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ on:
       }
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run: {
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ on:
       }
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run: {
         shell: bash
@@ -154,7 +154,7 @@ jobs:
       - {
         name: Build project,
         id: build,
-        run: mvn --batch-mode -DskipTests -DossindexSkip=true clean verify
+        run: mvn --batch-mode -DskipTests -DossindexSkip=true verify -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       }
       - {
         name: List secret GPG keys,

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -60,3 +60,11 @@ build:
               cd extension
               npm ci --ignore-scripts
               npm run build
+
+        - action: REPLACE
+          stepId: build
+          content:
+            name: Build project
+            id: build
+            # Omit clean: we must not delete the extension built in the previous step.
+            run: mvn --batch-mode -DskipTests -DossindexSkip=true verify -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/doc/changes/changes_2.9.5.md
+++ b/doc/changes/changes_2.9.5.md
@@ -1,4 +1,4 @@
-# Cloud Storage Extension 2.9.5, released 2026-05-15
+# Cloud Storage Extension 2.9.5, released 2026-05-18
 
 Code name: Migrate from Scala to Java
 


### PR DESCRIPTION
~~Pinned ubuntu runner to the same version as CI build because of suspected Jest incompatibility.~~

Extension built in previous workflow step was deleted by `mvn clean`. This restores the original version with a better comment that was lost in https://github.com/exasol/cloud-storage-extension/pull/404